### PR TITLE
Fix undefined object path issue

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -76,7 +76,7 @@ client.manager = new Manager({
                         });
                         await player.connect();
                         // check for spotify tracks played from /playlist command
-                        if (!serverQueue.songs[0].url) {
+                        if (!serverQueue.songs[0]?.url) {
                             const unersolvedTrack = TrackUtils.buildUnresolved({
                                 title: serverQueue.songs[0].title,
                                 author: serverQueue.songs[0].author,

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,8 @@ The eaisest way to start Boombox is by using docker. Docker will automaticly ins
 
 Make sure you have Docker and docker-compose installed. You can find instructions on how to install <a href="https://docs.docker.com/docker-for-windows/install/">Docker here, </a> and <a href="https://docs.docker.com/compose/install/"> docker-compose here. </a>
 
+Make sure you have Node >= 14 installed.
+
 ### Docker Install
 
 1.  Clone the repo


### PR DESCRIPTION
Closes #175 
Uses Node 14's optional chaining notation. Not sure what Node version has been the minimum required version before but now it requires at least Node 14, which I also added to the readme.